### PR TITLE
Add JSONResult interface

### DIFF
--- a/work-api/src/main/java/org/cytoscape/work/json/JSONResult.java
+++ b/work-api/src/main/java/org/cytoscape/work/json/JSONResult.java
@@ -1,0 +1,19 @@
+package org.cytoscape.work.json;
+
+/**
+ * This interface is intended to facilitate retrieving valid JSON strings from 
+ * {@link org.cytoscape.work.ObservableTask#getResults(Class)}. The primary intended user of this interface is CyREST,
+ * which will execute commands, and can benefit from returning JSON instead of Strings of unknown format, however, JSON
+ * data may be useful for apps that wish to retrieve data from another app's commands.
+ * 
+ * @author davidotasek
+ *
+ */
+public interface JSONResult {
+	
+	/**
+	 * 
+	 * @return A valid JSON String.
+	 */
+	public String getJSON();
+}


### PR DESCRIPTION
Add a JSONResult interface to the work api to to allow ObservableTasks to
return JSON formatted strings using getResults(JSONResult.class)