### PR TITLE
cytoscape/cytoscape#35: Move source:aggregate into a 'sources' profile, use HTTPS repos

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -32,7 +32,7 @@
             <enabled>false</enabled>
           </releases>
           <name>Cytoscape Snapshots</name>
-          <url>http://nrnb-nexus.ucsd.edu/repository/cytoscape_snapshots/</url>
+          <url>https://nrnb-nexus.ucsd.edu/repository/cytoscape_snapshots/</url>
         </repository>
         <repository>
           <id>cytoscape_releases</id>
@@ -43,7 +43,7 @@
             <enabled>true</enabled>
           </releases>
           <name>Cytoscape Releases</name>
-          <url>http://nrnb-nexus.ucsd.edu/repository/cytoscape_releases/</url>
+          <url>https://nrnb-nexus.ucsd.edu/repository/cytoscape_releases/</url>
         </repository>
         <repository>
           <id>cytoscape_thirdparty</id>
@@ -54,12 +54,12 @@
             <enabled>true</enabled>
           </releases>
           <name>Cytoscape Third Party</name>
-          <url>http://nrnb-nexus.ucsd.edu/repository/cytoscape_thirdparty/</url>
+          <url>https://nrnb-nexus.ucsd.edu/repository/cytoscape_thirdparty/</url>
         </repository>
         <repository>
           <id>central</id>
           <name>Central Repository</name>
-          <url>http://repo.maven.apache.org/maven2</url>
+          <url>https://repo.maven.apache.org/maven2</url>
           <releases>
             <enabled>true</enabled>
           </releases>

--- a/pom.xml
+++ b/pom.xml
@@ -86,22 +86,50 @@
 					<goals>deploy</goals>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>${maven-source-plugin.version}</version>
-				<executions>
-					<execution>
-						<id>aggregate-source</id>
-						<phase>package</phase>
-						<goals>
-							<goal>aggregate</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
+
+	<!--
+		The 'sources' profile builds the aggregated sources JAR that the
+		app-developer distribution ships (org.cytoscape:api-parent:jar:sources).
+
+		It is deliberately kept out of the default build.  source:aggregate is an
+		aggregator goal: it forks a generate-sources lifecycle over every module
+		below, and a forked lifecycle resolves its dependencies from the local
+		repository instead of the reactor.  Running at api-parent - module 2 of
+		the reactor - it looks for event-api before the reactor has built it, so
+		a build from a cold repository dies there.  Note that
+		-Dmaven.source.skip=true does not help: the fork is planned before the
+		skip flag is evaluated.  See cytoscape/cytoscape#35.
+
+		Run it as a second pass, after a normal build has populated ~/.m2:
+
+		    mvn clean install -DskipTests
+		    mvn install -Psources -DskipTests
+	-->
+	<profiles>
+		<profile>
+			<id>sources</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<version>${maven-source-plugin.version}</version>
+						<executions>
+							<execution>
+								<id>aggregate-source</id>
+								<phase>package</phase>
+								<goals>
+									<goal>aggregate</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 	<scm>
 		<connection>scm:git:git://github.com/cytoscape/cytoscape-api.git</connection>


### PR DESCRIPTION
Part of the multi-repository fix for cytoscape/cytoscape#35. Main description and full verification: **cytoscape/cytoscape#36**.

> ⚠️ **Must merge together with cytoscape/cytoscape-impl and cytoscape/cytoscape-app-developer.**

## Changes

**Move `source:aggregate` into a `sources` profile.** `api/pom.xml` bound maven-source-plugin's `aggregate` goal to the `package` phase of `api-parent`. That goal forks a `generate-sources` lifecycle over every module, and a forked lifecycle resolves dependencies from the local repository rather than the reactor — so at `api-parent`, module 2 of 122, it looked for `event-api` before the reactor had built it. Any build whose version was not already in `~/.m2` died there, which is every build right after a version bump.

Not a circular dependency: the module graph is acyclic and the reactor order was already correct. Also note `-Dmaven.source.skip=true` does not help — the fork is planned before the skip flag is evaluated.

The aggregated sources JAR is still needed by the app-developer kit, so it moves to a `sources` profile used as a second pass:

```sh
mvn clean install -DskipTests
mvn install -Psources -DskipTests
```

**Use HTTPS for Maven repositories.** The remaining `http://` URLs in `.travis.settings.xml` become `https://`; Maven 3.8.1+ blocks plain http. Repository ids are unchanged, so cached artifacts stay valid.

## Verification

Verified as part of the full seven-repository build on `develop` against a genuinely empty local repository with no settings file: 122 SUCCESS / 0 FAILURE on both passes, zero blocked-mirror errors. Details in cytoscape/cytoscape#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Updated artifact repository connections to use secure HTTPS endpoints.
  * Source archive generation is now optional, helping streamline standard builds.
  * Added guidance for generating aggregated source archives, including the required build steps and repository considerations.

* **Documentation**
  * Clarified how to enable optional source packaging and the conditions required for successful generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->